### PR TITLE
Fixed routers (need unique names)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ sleep:
 	sleep 20s
 
 test:
-	curl  -v http://localhost 2>&1 | grep "< HTTP"
+	curl -v http://localhost 2>&1 | grep "< HTTP"
 	curl -v http://whoami.localhost 2>&1 | grep "< HTTP"
 

--- a/json/nomade.json
+++ b/json/nomade.json
@@ -5,9 +5,7 @@
         "tags": [
             "traefik.enable=true",
             "traefik.connect=true",
-            "traefik.http.routers.router1.rule=Host(`localhost`)",
-            "traefik.http.routers.router1.service=service1",
-            "traefik.http.services.service1.loadBalancer.server.url=https://connect"
+            "traefik.http.routers.router1.rule=Host(`localhost`)"
         ],
         "address": "connect",
         "port": 443,

--- a/json/whoami1.json
+++ b/json/whoami1.json
@@ -5,7 +5,7 @@
         "tags": [
             "traefik.enable=true",
             "traefik.connect=false",
-            "traefik.http.routers.router1.rule=Host(`whoami.localhost`)"
+            "traefik.http.routers.router2.rule=Host(`whoami.localhost`)"
         ],
         "address": "whoami1",
         "port": 80


### PR DESCRIPTION
As far as I can tell router names always need to be unique. This fixes the missing router for me as mentioned in https://github.com/traefik/traefik/pull/7407#issuecomment-801829328