### PR TITLE
Added sidecar proxy example.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     image: consul:1.6.2
     ports:
       - 8500:8500
-    command: "agent -server -bootstrap -ui -client 0.0.0.0 -hcl 'connect { enabled = true }' -config-dir /json"
+    command: "agent -server -bootstrap -ui -client 0.0.0.0 -hcl 'connect { enabled = true }' -grpc-port 8502 -config-dir /json"
     volumes:
       - './json:/json'
 
@@ -41,6 +41,21 @@ services:
   whoami1:
     image: traefik/whoami
     hostname: whoami1
+
+  whoami-connect:
+    image: traefik/whoami
+    hostname: whoami-connect
+
+  whoami-connect-sidecar:
+    build: envoy
+    ports:
+      - 443
+    links:
+      - consul
+    command: "connect envoy -sidecar-for whoami-connect1"
+    environment:
+      CONSUL_HTTP_ADDR: http://consul:8500
+      CONSUL_GRPC_ADDR: consul:8502
 
   connect:
     image: hashicorpnomad/uuid-api:v5

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,0 +1,4 @@
+FROM consul:1.6.2 
+FROM envoyproxy/envoy:v1.11.2
+COPY --from=0 /bin/consul /bin/consul
+ENTRYPOINT ["consul"]

--- a/json/whoami-connect-sidecar.json
+++ b/json/whoami-connect-sidecar.json
@@ -1,0 +1,34 @@
+{
+    "service": {
+        "name": "whoami-connect-sidecar",
+        "tags": [
+            "traefik.enable=true",
+            "traefik.connect=true",
+            "traefik.http.routers.whoami-connect.rule=Host(`whoami-connect.localhost`)"
+        ],
+        "address": "whoami-connect-sidecar",
+        "port": 443,
+        "kind": "connect-proxy",
+        "checks": [
+            {
+                "Name": "Connect Sidecar Listening",
+                "TCP": "whoami-connect-sidecar:443",
+                "Interval": "10s"
+            },
+            {
+                "name": "Connect Sidecar Aliasing web",
+                "alias_service": "whoami-connect"
+            }
+        ],
+        "proxy": {
+            "destination_service_name": "whoami-connect",
+            "destination_service_id": "whoami-connect1",
+            "local_service_address": "whoami-connect",
+            "local_service_port": 80,
+            "config": {
+                "bind_address": "0.0.0.0",
+                "envoy_local_cluster_json": "{\n    \"name\": \"local_app\",\n    \"connect_timeout\": \"1s\",\n    \"type\": \"LOGICAL_DNS\",\n    \"hosts\": [\n        {\n            \"socket_address\": {\n                \"address\": \"whoami-connect\",\n                \"port_value\": 80\n            }\n        }\n    ]\n}"
+            }
+        }
+    }
+}

--- a/json/whoami-connect.json
+++ b/json/whoami-connect.json
@@ -1,0 +1,13 @@
+{
+    "service": {
+        "id": "whoami-connect1",
+        "name": "whoami-connect",
+        "tags": [
+            "traefik.enable=true",
+            "traefik.connect=true",
+            "traefik.http.routers.whoami-connect.rule=Host(`whoami-connect.localhost`)"
+        ],
+        "address": "whoami-connect",
+        "port": 80
+    }
+}


### PR DESCRIPTION
@jbdoumenjou as promised a sidecar example. Please do not modify ` json/whoami-connect-sidecar.json` and if you modify the tags in ` json/whoami-connect.json` you must copy them over to the sidecar file. The reasoning is that the sidecar json would be automatically created. If you look at the minimal example in https://www.consul.io/docs/connect/registration/sidecar-service#minimal-example -- you will see that I actually did the "expanded" form to get it working at all in docker-compose. This is because the sidecar and service are usually on the same host etc…